### PR TITLE
Modified tasks to be reused instead of create/destroy

### DIFF
--- a/include/audio/audio.hpp
+++ b/include/audio/audio.hpp
@@ -27,3 +27,45 @@ void setVolume(byte volume) {
 }
 
 }
+
+/*
+AUDIO FILE KEY 
+  audio::playTrack(1); // Play Move 1
+  delay(8000);
+  audio::playTrack(3); // Play Move 2 
+  delay(7000);
+  audio::playTrack(5); // Play Move 3 
+  delay(5000);
+  audio::playTrack(7); // Play Move 4
+  delay(5000);
+  audio::playTrack(9); // Play Move 5
+  delay(5000);
+  audio::playTrack(11); // Play Move 7
+  delay(8000);
+  audio::playTrack(13); // Play Move 8
+  delay(4000);
+  audio::playTrack(15); // Play Move 10
+  delay(11000);
+  audio::playTrack(17); // Play Move 11
+  delay(8000);
+  audio::playTrack(19); // Play Move 12
+  delay(5000);
+  audio::playTrack(21); // Play Whoops
+  delay(12000);
+  audio::playTrack(23); // Play Start Game
+  delay(9000);
+  audio::playTrack(25); // Play Yellow start
+  delay(5000);
+  audio::playTrack(27); // Play Pink scan
+  delay(5000);
+  audio::playTrack(29); // Play Blue scan
+  delay(5000);
+  audio::playTrack(31); // Play Green scan
+  delay(5000);
+  audio::playTrack(33); // Play Yellow scan
+  delay(5000);
+  audio::playTrack(35); // Play Collision
+  delay(8000);
+  adui::playTrack(37);  // Play slide
+  delay(10000);
+*/

--- a/include/audio/audio.hpp
+++ b/include/audio/audio.hpp
@@ -1,0 +1,29 @@
+#include <Arduino.h>
+extern HardwareSerial mySerial; // Declare mySerial as an external variable
+
+namespace audio {
+
+void playTrack(byte filenum) {
+  mySerial.write(0x7E);
+  mySerial.write(0xFF);
+  mySerial.write(0x06);
+  mySerial.write(0x03);
+  mySerial.write(0x00);
+  mySerial.write(0x00);
+  mySerial.write(filenum);
+  mySerial.write(0xEF);
+}
+
+void setVolume(byte volume) {
+  if (volume > 30) volume = 30; // Ensure volume is within range
+  mySerial.write(0x7E); // Start byte
+  mySerial.write(0xFF); // Version
+  mySerial.write(0x06); // Length
+  mySerial.write(0x06); // Command: Set volume
+  mySerial.write(0x00); // Feedback (0 = no feedback)
+  mySerial.write(0x00); // High byte of parameter (always 0 for volume)
+  mySerial.write(volume); // Low byte of parameter (volume level)
+  mySerial.write(0xEF); // End byte
+}
+
+}

--- a/include/game_logic/logic_board.hpp
+++ b/include/game_logic/logic_board.hpp
@@ -41,7 +41,7 @@ namespace logic {
 
             int findNextOpenHome(int color);
             int findNextOpenStart(int color);
-            int checkSlide(LogicPlayer* Player, int location);
+            int checkSlide(LogicPlayer* Player, int location, piece_detection::PieceDetection* pieceDetection);
 
             bool allPiecesPlaced();
             bool allPiecesOnStart(LogicPlayer* Player, LogicTerminal* Terminal, piece_detection::PieceDetection* pieceDetection);

--- a/include/game_logic/logic_controller.hpp
+++ b/include/game_logic/logic_controller.hpp
@@ -46,7 +46,7 @@ namespace logic
             void startGame();
             void takeTurn();
             void nextPlayer();
-            void indicate_moves(const vector<int>& possibleMoves, int color, int start_tile, TaskHandle_t* taskHandle);
+            void indicate_moves(const vector<int>& possibleMoves, int color, int start_tile);
     };
     
     void ledTask(void* pvParameters);

--- a/include/game_logic/logic_player.hpp
+++ b/include/game_logic/logic_player.hpp
@@ -22,7 +22,7 @@ namespace logic {
             void setPlayerColor(int movingFrom, int color, int player);
             int getPlayerCount();
             void setPlayerCount(rfid::RfidScanner* Scanner, LogicTerminal* Terminal);
-            void handleSelfCollision(LogicBoard* Board, int possibleMove, vector<int> &possibleMoves, int index);
+            void handleSelfCollision(LogicBoard* Board, int possibleMove, vector<int> &possibleMoves, int index, int chip, int movingFrom);
 
             int currentPlayer;
             vector<int> playerColors = {0, 0, 0, 0}; 

--- a/include/game_logic/logic_special.hpp
+++ b/include/game_logic/logic_special.hpp
@@ -20,7 +20,7 @@ namespace logic {
             LogicSpecial();
             void handleWhoops(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, LogicCalculations* Calc, vector<int> possibleMoves, piece_detection::PieceDetection* pieceDetection);
             void handleSeven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, LogicCalculations* Calc, vector<int> possibleMoves, int movingFrom, TaskHandle_t led_task, piece_detection::PieceDetection* pieceDetection);
-            void moveSecondPawn(LogicBoard* Board, LogicPlayer* Player, int distance, int start);
+            void moveSecondPawn(LogicBoard* Board, LogicPlayer* Player, int distance, int start, piece_detection::PieceDetection* pieceDetection);
             void handleEleven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, vector<int> possibleMoves, int movingFrom, piece_detection::PieceDetection* pieceDetection);
     };
 }

--- a/include/game_logic/logic_special.hpp
+++ b/include/game_logic/logic_special.hpp
@@ -19,7 +19,7 @@ namespace logic {
         public:
             LogicSpecial();
             void handleWhoops(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, LogicCalculations* Calc, vector<int> possibleMoves, piece_detection::PieceDetection* pieceDetection);
-            void handleSeven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, LogicCalculations* Calc, vector<int> possibleMoves, int movingFrom, TaskHandle_t led_task, piece_detection::PieceDetection* pieceDetection);
+            void handleSeven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, LogicCalculations* Calc, vector<int> possibleMoves, int movingFrom, piece_detection::PieceDetection* pieceDetection);
             void moveSecondPawn(LogicBoard* Board, LogicPlayer* Player, int distance, int start, piece_detection::PieceDetection* pieceDetection);
             void handleEleven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, vector<int> possibleMoves, int movingFrom, piece_detection::PieceDetection* pieceDetection);
     };

--- a/include/led_control/led.hpp
+++ b/include/led_control/led.hpp
@@ -43,12 +43,22 @@ namespace led_control
 
   void showCorrectPositions(logic::LogicBoard* board);
   void ledTask(void *pvParameters);
-  void indicate_moves(const std::vector<int>& possibleMoves, int color, int start_tile, TaskHandle_t* taskHandle);
-  void showWinner(int player_number);
-  void showStartPositions(int num_players, TaskHandle_t* taskHandle);
+  void stopLedTask();
+
+  void indicate_moves(const std::vector<int>& possibleMoves, int color, int start_tile);
+  void stopIndicateMoves();
+
+  void showPlayerPositions(int player_number, const logic::LogicBoard& board);
+  void stopPlayerPositions();
+
+  void showStartPositions(int num_players);
+  void stopStartPositions();
   void prvShowStartPositions(void *pvParameters);
-  void slidePiece(SlideStruct slide, TaskHandle_t* taskHandle);
-  void showPlayerPositions(int player_number, TaskHandle_t* taskHandle, const logic::LogicBoard& board);
+
+  void slidePiece(SlideStruct slide);
+  void stopSlide();
   void prvShowSlide(void *pvParameters);
+  
+  void showWinner(int player_number);
 } //namespace led_control
 #endif // LED_CONTROL_H

--- a/include/led_control/led.hpp
+++ b/include/led_control/led.hpp
@@ -48,6 +48,7 @@ namespace led_control
   void showStartPositions(int num_players, TaskHandle_t* taskHandle);
   void prvShowStartPositions(void *pvParameters);
   void slidePiece(SlideStruct slide, TaskHandle_t* taskHandle);
+  void showPlayerPositions(int player_number, TaskHandle_t* taskHandle, logic::LogicBoard* board);
 
 } //namespace led_control
 #endif // LED_CONTROL_H

--- a/include/led_control/led.hpp
+++ b/include/led_control/led.hpp
@@ -39,5 +39,7 @@ namespace led_control
   void ledTask(void *pvParameters);
   void indicate_moves(const std::vector<int>& possibleMoves, int color, int start_tile, TaskHandle_t* taskHandle);
   void showWinner(int player_number);
+  void showStartPositions(int num_players, TaskHandle_t* taskHandle);
+  void prvShowStartPositions(void *pvParameters);
 } //namespace led_control
 #endif // LED_CONTROL_H

--- a/include/led_control/led.hpp
+++ b/include/led_control/led.hpp
@@ -48,7 +48,7 @@ namespace led_control
   void showStartPositions(int num_players, TaskHandle_t* taskHandle);
   void prvShowStartPositions(void *pvParameters);
   void slidePiece(SlideStruct slide, TaskHandle_t* taskHandle);
-  void showPlayerPositions(int player_number, TaskHandle_t* taskHandle, logic::LogicBoard* board);
-
+  void showPlayerPositions(int player_number, TaskHandle_t* taskHandle, const logic::LogicBoard& board);
+  void prvShowSlide(void *pvParameters);
 } //namespace led_control
 #endif // LED_CONTROL_H

--- a/include/led_control/led.hpp
+++ b/include/led_control/led.hpp
@@ -18,6 +18,12 @@ namespace logic {
 
 namespace led_control
 {
+  struct SlideStruct {
+    int start_location;
+    int end_location;
+    int color;
+  };
+
   /// @brief Method to indicate a move from one tile to another
   /// @param from Index of the current tile
   /// @param to Index of the tile to move to
@@ -41,5 +47,7 @@ namespace led_control
   void showWinner(int player_number);
   void showStartPositions(int num_players, TaskHandle_t* taskHandle);
   void prvShowStartPositions(void *pvParameters);
+  void slidePiece(SlideStruct slide, TaskHandle_t* taskHandle);
+
 } //namespace led_control
 #endif // LED_CONTROL_H

--- a/src/game_logic/logic_board.cpp
+++ b/src/game_logic/logic_board.cpp
@@ -161,8 +161,7 @@ namespace logic {
             int slideIndex= find(kSlideStartLocations.begin(), kSlideStartLocations.end(), location) - kSlideStartLocations.begin();
             Serial.println("Move the piece to the end of the slide (location " + String(kSlideEndLocations[slideIndex]) + ") and send any pawns you collide with back to their Start.");
             led_control::SlideStruct slide = {location, kSlideEndLocations[slideIndex], color};
-            TaskHandle_t slideLights = NULL;
-            led_control::slidePiece(slide, &slideLights);
+            led_control::slidePiece(slide);
             for (int i = kSlideStartLocations[slideIndex] + 1; i <= kSlideEndLocations[slideIndex]; i++) {
                 if (currentLocations[i] != 0) {
                     currentLocations[findNextOpenStart(currentLocations[i])] = currentLocations[i];
@@ -172,10 +171,7 @@ namespace logic {
             currentLocations[kSlideEndLocations[slideIndex]] = currentLocations[location];
             currentLocations[location] = 0;
             while (!pieceDetection->hasChangedSensor()) {}
-            if (slideLights != NULL) {
-                vTaskDelete(slideLights); // turn off leds
-                slideLights = NULL;
-            }
+            led_control::stopSlide();
             return slideIndex;
         }
         return location;

--- a/src/game_logic/logic_board.cpp
+++ b/src/game_logic/logic_board.cpp
@@ -172,7 +172,7 @@ namespace logic {
             currentLocations[location] = 0;
             while (!pieceDetection->hasChangedSensor()) {}
             led_control::stopSlide();
-            return slideIndex;
+            return kSlideEndLocations[slideIndex];
         }
         return location;
     }

--- a/src/game_logic/logic_board.cpp
+++ b/src/game_logic/logic_board.cpp
@@ -4,8 +4,8 @@
 #include "game_logic/logic_player.hpp"
 #include "game_logic/logic_terminal.hpp"
 #include "piece_detection/piece_detection.hpp"
+#include "led_control/led.hpp"
 #include <algorithm>
-#include <FastLED.h>
 
 namespace logic {
 
@@ -140,7 +140,7 @@ namespace logic {
     }
 
     //Returns the new location of the piece
-    int LogicBoard::checkSlide(LogicPlayer* Player, int location) {
+    int LogicBoard::checkSlide(LogicPlayer* Player, int location, piece_detection::PieceDetection* pieceDetection) {
         if (find(kSlideStartLocations.begin(), kSlideStartLocations.end(), location) != kSlideStartLocations.end()) {
             //Can't slide on your own color
             int color = currentLocations[location];
@@ -160,6 +160,9 @@ namespace logic {
             //Otherwise slide
             int slideIndex= find(kSlideStartLocations.begin(), kSlideStartLocations.end(), location) - kSlideStartLocations.begin();
             Serial.println("Move the piece to the end of the slide (location " + String(kSlideEndLocations[slideIndex]) + ") and send any pawns you collide with back to their Start.");
+            led_control::SlideStruct slide = {location, kSlideEndLocations[slideIndex], color};
+            TaskHandle_t slideLights = NULL;
+            led_control::slidePiece(slide, &slideLights);
             for (int i = kSlideStartLocations[slideIndex] + 1; i <= kSlideEndLocations[slideIndex]; i++) {
                 if (currentLocations[i] != 0) {
                     currentLocations[findNextOpenStart(currentLocations[i])] = currentLocations[i];
@@ -168,6 +171,8 @@ namespace logic {
             }
             currentLocations[kSlideEndLocations[slideIndex]] = currentLocations[location];
             currentLocations[location] = 0;
+            while (!pieceDetection->hasChangedSensor()) {}
+            vTaskDelete(slideLights); // turn off leds
             return slideIndex;
         }
         return location;
@@ -185,14 +190,9 @@ namespace logic {
 
     bool LogicBoard::allPiecesOnStart(LogicPlayer* Player, LogicTerminal* Terminal, piece_detection::PieceDetection* pieceDetection) {
         int numberOfFilledAreas = 0;
-        // auto data = pieceDetection->getDataCopy();
+
         pieceDetection->updateBoard(this); // update the currentLocations by reading all sensors
         pieceDetection->getChangedSensors(); // clear the changed sensors
-
-        // for (int i = 0; i < 80; i++) {
-        //     Serial.printf("%d = %d, ", i, currentLocations[i]);
-        // }
-        // Serial.println();
 
         //Check if 50, 51, 52 occupied
         //If true increment numberOfFilledAreas
@@ -204,6 +204,9 @@ namespace logic {
             currentLocations[52] = 1;
             Player->playerColors[0] = 1;
         }
+        else {
+            Serial.printf("50:%d, 51:%d, 52:%d\n", currentLocations[50], currentLocations[51], currentLocations[52]);
+        }
         
         //Check if 59, 60, 61 occupied
         //If true increment numberOfFilledAreas
@@ -214,6 +217,9 @@ namespace logic {
             currentLocations[60] = 2;
             currentLocations[61] = 2;
             Player->playerColors[1] = 2;
+        }
+        else {
+            Serial.printf("59:%d, 60:%d, 61:%d\n", currentLocations[59], currentLocations[60], currentLocations[61]);
         }
 
         
@@ -227,6 +233,9 @@ namespace logic {
             currentLocations[70] = 3;
             Player->playerColors[2] = 3;
         }
+        else {
+            Serial.printf("68:%d, 69:%d, 70:%d\n", currentLocations[68], currentLocations[69], currentLocations[70]);
+        }
         
         //Check if 77, 78, 79 occupied
         //If true increment numberOfFilledAreas
@@ -237,6 +246,9 @@ namespace logic {
             currentLocations[78] = 4;
             currentLocations[79] = 4;
             Player->playerColors[3] = 4;
+        }
+        else {
+            Serial.printf("77:%d, 78:%d, 79:%d\n", currentLocations[77], currentLocations[78], currentLocations[79]);
         }
         
         //For terminal testing

--- a/src/game_logic/logic_board.cpp
+++ b/src/game_logic/logic_board.cpp
@@ -172,7 +172,10 @@ namespace logic {
             currentLocations[kSlideEndLocations[slideIndex]] = currentLocations[location];
             currentLocations[location] = 0;
             while (!pieceDetection->hasChangedSensor()) {}
-            vTaskDelete(slideLights); // turn off leds
+            if (slideLights != NULL) {
+                vTaskDelete(slideLights); // turn off leds
+                slideLights = NULL;
+            }
             return slideIndex;
         }
         return location;

--- a/src/game_logic/logic_calculations.cpp
+++ b/src/game_logic/logic_calculations.cpp
@@ -385,7 +385,7 @@ namespace logic {
 
         //Handle if a possible move lands on one of your own pawns
         for (int i = 0; i < possibleMoves.size(); i++) {
-            Player->handleSelfCollision(Board, possibleMoves[i], possibleMoves, i);
+            Player->handleSelfCollision(Board, possibleMoves[i], possibleMoves, i, distance, selectedPawn);
         }
         return possibleMoves;
     }

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -62,10 +62,6 @@ namespace logic
 
 
         Serial.println("Setup Complete");
-        Serial.println("Press any key to start game");
-        while (!Serial.available()) {}
-        Serial.read();
-        Serial.println("Game Started");
         Player.currentPlayer = 0;
         Player.setPlayerCount(&Scanner, &Terminal);
         Serial.println("Player count: " + String(Player.getPlayerCount()));
@@ -77,6 +73,8 @@ namespace logic
         led_control::showStartPositions(Player.getPlayerCount(), &startPosLights);
         while (!Board.allPiecesOnStart(&Player, &Terminal, &pieceDetection)) {vTaskDelay(pdMS_TO_TICKS(500));};
         vTaskDelete(startPosLights); // turn off leds
+        Serial.println("All pieces placed on start locations");
+        Serial.println("Game starting...");
 
         while (!Board.checkWinCondition(&Player)){
             led_control::showCorrectPositions(&Board);
@@ -94,9 +92,9 @@ namespace logic
         Serial.println("Player " + String(Player.currentPlayer + 1) + "'s turn");
         Serial.println();
 
-        //Flash LEDs for current player pieces
-        TaskHandle_t currentPlayerLeds = NULL;
-        led_control::showPlayerPositions(Player.currentPlayer, &currentPlayerLeds, &Board);
+        // //Flash LEDs for current player pieces
+        // TaskHandle_t currentPlayerLeds = NULL;
+        // led_control::showPlayerPositions(Player.currentPlayer, &currentPlayerLeds, Board);
 
         //Scan chip
         Serial.println("Draw and scan a chip");
@@ -109,7 +107,6 @@ namespace logic
         Terminal.t_displayChipInstructions(&Scanner);
         
         // Stop showing where all pieces should be
-        vTaskDelete(currentPlayerLeds); // turn off leds
         FastLED.clear();
         FastLED.show();
 

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -118,7 +118,7 @@ namespace logic
         //If there are no possible moves, go to next player
         if (possibleMoves.size() == 0) {
             Serial.println("No possible moves");
-            vTaskDelay(pdMS_TO_TICKS(4000)); // wait for a bit before going to next player
+            vTaskDelay(pdMS_TO_TICKS(2000)); // wait for a bit before going to next player
             nextPlayer();
             return;
         }

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -72,7 +72,10 @@ namespace logic
         TaskHandle_t startPosLights = NULL;
         led_control::showStartPositions(Player.getPlayerCount(), &startPosLights);
         while (!Board.allPiecesOnStart(&Player, &Terminal, &pieceDetection)) {vTaskDelay(pdMS_TO_TICKS(500));};
-        vTaskDelete(startPosLights); // turn off leds
+        if (startPosLights != NULL) {
+            vTaskDelete(startPosLights); // turn off leds
+            startPosLights = NULL;
+        }
         Serial.println("All pieces placed on start locations");
         Serial.println("Game starting...");
 
@@ -105,7 +108,10 @@ namespace logic
             scan_val = Scanner.scanCard();
         }        
         Scanner.lastChip = scan_val;
-        vTaskDelete(currentPlayerLeds);
+        if (currentPlayerLeds != NULL) {
+            vTaskDelete(currentPlayerLeds); // turn off leds
+            currentPlayerLeds = NULL;
+        }
         Terminal.t_displayChipInstructions(&Scanner);
         
         // Stop showing where all pieces should be
@@ -152,7 +158,10 @@ namespace logic
                 while (!pieceDetection.hasChangedSensor()) {} // wait until player chooses a piece
                 newLocation = piece_detection::kSensorMap.at(pieceDetection.getChangedSensors().at(0));
             }
-            vTaskDelete(led_task); // turn off leds
+            if (led_task != NULL) {
+                vTaskDelete(led_task); // turn off leds
+                led_task = NULL;
+            }
             Serial.printf("\nMoving player %d's piece %d ----> %d\n", Player.currentPlayer + 1, Calc.movingFrom, newLocation);
 
             //If piece hits other piece, send other piece back to start
@@ -166,7 +175,10 @@ namespace logic
             //Slide if on slide square
             newLocation = Board.checkSlide(&Player, newLocation, &pieceDetection);
         } else if (Scanner.lastChip == 0 || Scanner.lastChip == 11) {
-            vTaskDelete(led_task); // turn off leds
+            if (led_task != NULL) {
+                vTaskDelete(led_task); // turn off leds
+                led_task = NULL;
+            }
         }
         
         if (Board.checkWinCondition(&Player)) {

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -151,9 +151,7 @@ namespace logic
 
             //If piece hits other piece, send other piece back to start
             if (Board.currentLocations[newLocation] != 0) {
-                Serial.print("COLLISION: Send opponent's piece back to start. Press any key to confirm: ");
-                while (!Serial.available()) {}
-                Serial.read();
+                Serial.print("COLLISION: Send opponent's piece back to start.");
                 Board.currentLocations[Board.findNextOpenStart(Board.currentLocations[newLocation])] = Board.currentLocations[newLocation];
             }
             Board.currentLocations[newLocation] = Board.currentLocations[Calc.movingFrom];

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -73,7 +73,10 @@ namespace logic
 
         //code to ensure setup is done correctly
         Serial.println("Please place pieces on start locations");
-        while (!Board.allPiecesOnStart(&Player, &Terminal, &pieceDetection)) {};
+        TaskHandle_t startPosLights = NULL;
+        led_control::showStartPositions(Player.getPlayerCount(), &startPosLights);
+        while (!Board.allPiecesOnStart(&Player, &Terminal, &pieceDetection)) {vTaskDelay(500 / portTICK_PERIOD_MS);};
+        vTaskDelete(startPosLights); // turn off leds
 
         while (!Board.checkWinCondition(&Player)){
             led_control::showCorrectPositions(&Board);

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -93,6 +93,11 @@ namespace logic
     void LogicController::takeTurn() {
         Serial.println("Player " + String(Player.currentPlayer + 1) + "'s turn");
         Serial.println();
+
+        //Flash LEDs for current player pieces
+        TaskHandle_t currentPlayerLeds = NULL;
+        led_control::showPlayerPositions(Player.currentPlayer, &currentPlayerLeds, &Board);
+
         //Scan chip
         Serial.println("Draw and scan a chip");
         
@@ -104,6 +109,7 @@ namespace logic
         Terminal.t_displayChipInstructions(&Scanner);
         
         // Stop showing where all pieces should be
+        vTaskDelete(currentPlayerLeds); // turn off leds
         FastLED.clear();
         FastLED.show();
 

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -75,7 +75,7 @@ namespace logic
         Serial.println("Please place pieces on start locations");
         TaskHandle_t startPosLights = NULL;
         led_control::showStartPositions(Player.getPlayerCount(), &startPosLights);
-        while (!Board.allPiecesOnStart(&Player, &Terminal, &pieceDetection)) {vTaskDelay(500 / portTICK_PERIOD_MS);};
+        while (!Board.allPiecesOnStart(&Player, &Terminal, &pieceDetection)) {vTaskDelay(pdMS_TO_TICKS(500));};
         vTaskDelete(startPosLights); // turn off leds
 
         while (!Board.checkWinCondition(&Player)){
@@ -158,7 +158,7 @@ namespace logic
             Board.currentLocations[Calc.movingFrom] = 0;
 
             //Slide if on slide square
-            newLocation = Board.checkSlide(&Player, newLocation);
+            newLocation = Board.checkSlide(&Player, newLocation, &pieceDetection);
         } else if (Scanner.lastChip == 0 || Scanner.lastChip == 11) {
             vTaskDelete(led_task); // turn off leds
         }

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -115,6 +115,7 @@ namespace logic
         //If there are no possible moves, go to next player
         if (possibleMoves.size() == 0) {
             Serial.println("No possible moves");
+            vTaskDelay(pdMS_TO_TICKS(1000)); // wait for a bit before going to next player
             nextPlayer();
             return;
         }

--- a/src/game_logic/logic_controller.cpp
+++ b/src/game_logic/logic_controller.cpp
@@ -93,8 +93,8 @@ namespace logic
         Serial.println();
 
         // //Flash LEDs for current player pieces
-        // TaskHandle_t currentPlayerLeds = NULL;
-        // led_control::showPlayerPositions(Player.currentPlayer, &currentPlayerLeds, Board);
+        TaskHandle_t currentPlayerLeds = NULL;
+        led_control::showPlayerPositions(Player.currentPlayer+1, &currentPlayerLeds, Board);
 
         //Scan chip
         Serial.println("Draw and scan a chip");
@@ -103,7 +103,9 @@ namespace logic
         while (scan_val == rfid::kInvalidCardName)
         {
             scan_val = Scanner.scanCard();
-        }        Scanner.lastChip = scan_val;
+        }        
+        Scanner.lastChip = scan_val;
+        vTaskDelete(currentPlayerLeds);
         Terminal.t_displayChipInstructions(&Scanner);
         
         // Stop showing where all pieces should be
@@ -118,7 +120,7 @@ namespace logic
         //If there are no possible moves, go to next player
         if (possibleMoves.size() == 0) {
             Serial.println("No possible moves");
-            vTaskDelay(pdMS_TO_TICKS(1000)); // wait for a bit before going to next player
+            vTaskDelay(pdMS_TO_TICKS(4000)); // wait for a bit before going to next player
             nextPlayer();
             return;
         }

--- a/src/game_logic/logic_player.cpp
+++ b/src/game_logic/logic_player.cpp
@@ -59,10 +59,29 @@ namespace logic {
         lastChip = -1;
     }
 
-    void LogicPlayer::handleSelfCollision(LogicBoard* Board, int possibleMove, vector<int> &possibleMoves, int index) {    
+    void LogicPlayer::handleSelfCollision(LogicBoard* Board, int possibleMove, vector<int> &possibleMoves, int index, int chip, int movingFrom) {    
         int color = getPlayerColor(currentPlayer);
         if (Board->currentLocations[possibleMove] == color) {
             possibleMoves.erase(possibleMoves.begin() + index);
+        }
+
+        //If possible move is a slide start, check if the player has any other pawns in that slide
+        //But don't check slides on your own side of the board
+        if (color == 1 && (possibleMove == 0 || possibleMove == 6)) {return;} //Yellow
+        else if (color == 2 && (possibleMove == 11 || possibleMove == 17)) {return;} //Green
+        else if (color == 3 && (possibleMove == 22 || possibleMove == 28)) {return;} //Red
+        else if (color == 4 && (possibleMove == 33 || possibleMove == 39)) {return;} //Blue
+
+        if (find(kSlideStartLocations.begin(), kSlideStartLocations.end(), possibleMove) != kSlideStartLocations.end()) {
+            for (int i = possibleMove; i <= possibleMove + 3; i++) {
+                if (chip == 10 && i == possibleMove + 1 && possibleMove + 1 == movingFrom) {
+                    continue; //Don't check the second location of the slide on a 10 for backwards 1
+                }
+                if (Board->currentLocations[i] == color) {
+                    possibleMoves.erase(possibleMoves.begin() + index);
+                    break;
+                }
+            }
         }
     }
 } 

--- a/src/game_logic/logic_special.cpp
+++ b/src/game_logic/logic_special.cpp
@@ -58,8 +58,10 @@ namespace logic {
             Board->currentLocations[location] = color;
             Board->currentLocations[movingFrom] = 0;
             
-            // turn off leds
-            vTaskDelete(led_task); 
+            if (led_task != NULL) {
+                vTaskDelete(led_task); // turn off leds
+                led_task = NULL;
+            }
             FastLED.clear();
             FastLED.show();
 
@@ -125,7 +127,10 @@ namespace logic {
         TaskHandle_t led_task = NULL;
         led_control::indicate_moves({location}, color, start, &led_task);
         while (!pieceDetection->hasChangedSensor()) {} // wait until player chooses a piece
-        vTaskDelete(led_task); // turn off leds
+        if (led_task != NULL) {
+            vTaskDelete(led_task); // turn off leds
+            led_task = NULL;
+        }
         FastLED.clear();
         FastLED.show();
         

--- a/src/game_logic/logic_special.cpp
+++ b/src/game_logic/logic_special.cpp
@@ -36,7 +36,7 @@ namespace logic {
         }
     }
 
-    void LogicSpecial::handleSeven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, LogicCalculations* Calc, vector<int> possibleMoves, int movingFrom, TaskHandle_t led_task, piece_detection::PieceDetection* pieceDetection) {
+    void LogicSpecial::handleSeven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, LogicCalculations* Calc, vector<int> possibleMoves, int movingFrom, piece_detection::PieceDetection* pieceDetection) {
         if (Scanner->lastChip == 7) {
             int color = Player->getPlayerColor(Player->currentPlayer);
             Serial.print("Place your pawn in a valid location: ");
@@ -58,10 +58,7 @@ namespace logic {
             Board->currentLocations[location] = color;
             Board->currentLocations[movingFrom] = 0;
             
-            if (led_task != NULL) {
-                vTaskDelete(led_task); // turn off leds
-                led_task = NULL;
-            }
+            led_control::stopIndicateMoves();
             FastLED.clear();
             FastLED.show();
 
@@ -124,13 +121,10 @@ namespace logic {
                 location++;
             }
         }
-        TaskHandle_t led_task = NULL;
-        led_control::indicate_moves({location}, color, start, &led_task);
+        led_control::indicate_moves({location}, color, start);
         while (!pieceDetection->hasChangedSensor()) {} // wait until player chooses a piece
-        if (led_task != NULL) {
-            vTaskDelete(led_task); // turn off leds
-            led_task = NULL;
-        }
+        vTaskDelay(pdMS_TO_TICKS(500));
+        led_control::stopIndicateMoves();
         FastLED.clear();
         FastLED.show();
         

--- a/src/game_logic/logic_special.cpp
+++ b/src/game_logic/logic_special.cpp
@@ -71,26 +71,31 @@ namespace logic {
             }
             Serial.println("You have " + String(secondDistance) + " spaces left to move with your second pawn.");
             Serial.print("Possible second pawn current locations(s): ");
+            std::vector<int> validPieces;
             for (int i = 0; i < 44; i++) {
                 if (Board->currentLocations[i] == color && i != location && i != newLocation) {
                     Serial.printf("%d ", i);
+                    validPieces.push_back(i);
                 }
             }
             for (int i = 0; i < kSafetyLocations.size(); i++) {
                 if (Board->currentLocations[kSafetyLocations[i]] == color && kSafetyLocations[i] != location) {
                     Serial.printf("%d ", kSafetyLocations[i]);
+                    validPieces.push_back(kSafetyLocations[i]);
                 }
             }
             Serial.println();
             Serial.print("Select a pawn location to move from: ");
+            led_control::indicate_moves(validPieces, Player->getPlayerColor(Player->currentPlayer), 255);
             while (!pieceDetection->hasChangedSensor()) {} // wait until player chooses a piece
             int secondPawnStart = piece_detection::kSensorMap.at(pieceDetection->getChangedSensors().at(0));
-            while (Board->currentLocations[secondPawnStart] != color) {
+            while ((Board->currentLocations[secondPawnStart] != color) || secondPawnStart == location || secondPawnStart == newLocation) {
                 Serial.println("Invalid pawn");
                 Serial.print("Select a pawn to move: ");
                 while (!pieceDetection->hasChangedSensor()) {} // wait until player chooses a piece
                 secondPawnStart = piece_detection::kSensorMap.at(pieceDetection->getChangedSensors().at(0));
             }
+            led_control::stopIndicateMoves();
             moveSecondPawn(Board, Player, secondDistance, secondPawnStart, pieceDetection);
         }
     }

--- a/src/game_logic/logic_special.cpp
+++ b/src/game_logic/logic_special.cpp
@@ -48,6 +48,13 @@ namespace logic {
                 while (!pieceDetection->hasChangedSensor()) {} // wait until player chooses a piece
                 location = piece_detection::kSensorMap.at(pieceDetection->getChangedSensors().at(0));
             }
+            
+            //If piece hits other piece, send other piece back to start
+            if (Board->currentLocations[location] != 0) {
+                Serial.print("COLLISION: Send opponent's piece back to start.");
+                Board->currentLocations[Board->findNextOpenStart(Board->currentLocations[location])] = Board->currentLocations[location];
+            }
+            
             Board->currentLocations[location] = color;
             Board->currentLocations[movingFrom] = 0;
             

--- a/src/game_logic/logic_special.cpp
+++ b/src/game_logic/logic_special.cpp
@@ -31,7 +31,7 @@ namespace logic {
             Board->currentLocations[opponentPawn] = Player->getPlayerColor(Player->currentPlayer);
             Board->currentLocations[Calc->movingFrom] = 0;
             //Slide if on slide square
-            int newLocation = Board->checkSlide(Player, opponentPawn);
+            int newLocation = Board->checkSlide(Player, opponentPawn, pieceDetection);
             Serial.println("Opponent's pawn has been sent back to start and your pawn has been set in their previous location.");
         }
     }
@@ -57,7 +57,7 @@ namespace logic {
             FastLED.show();
 
             //Slide if on slide square
-            int newLocation = Board->checkSlide(Player, location);
+            int newLocation = Board->checkSlide(Player, location, pieceDetection);
             int firstDistance = Calc->getDistance(Player, movingFrom, location);
             int secondDistance = 7 - firstDistance;
             if (secondDistance == 0) {
@@ -85,11 +85,11 @@ namespace logic {
                 while (!pieceDetection->hasChangedSensor()) {} // wait until player chooses a piece
                 secondPawnStart = piece_detection::kSensorMap.at(pieceDetection->getChangedSensors().at(0));
             }
-            moveSecondPawn(Board, Player, secondDistance, secondPawnStart);
+            moveSecondPawn(Board, Player, secondDistance, secondPawnStart, pieceDetection);
         }
     }
 
-    void LogicSpecial::moveSecondPawn(LogicBoard* Board, LogicPlayer* Player, int distance, int start) { // Need to finish
+    void LogicSpecial::moveSecondPawn(LogicBoard* Board, LogicPlayer* Player, int distance, int start, piece_detection::PieceDetection* pieceDetection) { // Need to finish
         Serial.print("Move your second pawn " + String(distance) + " spaces forward.");
         Board->currentLocations[start] = 0;
         
@@ -130,7 +130,7 @@ namespace logic {
         Board->currentLocations[location] = color;
         Board->currentLocations[start] = 0;
         //Slide if on slide square
-        location = Board->checkSlide(Player, location);
+        location = Board->checkSlide(Player, location, pieceDetection);
     }
 
     void LogicSpecial::handleEleven(rfid::RfidScanner* Scanner, LogicBoard* Board, LogicPlayer* Player, vector<int> possibleMoves, int movingFrom, piece_detection::PieceDetection* pieceDetection) {
@@ -150,7 +150,7 @@ namespace logic {
             if (Board->currentLocations[endLocation] == 0) {
                 Board->currentLocations[endLocation] = color;
                 //Slide if on slide square
-                endLocation = Board->checkSlide(Player, endLocation);
+                endLocation = Board->checkSlide(Player, endLocation, pieceDetection);
                 Board->currentLocations[movingFrom] = 0;
             } 
             else if (endLocation == (movingFrom + 11)%44) {
@@ -158,17 +158,17 @@ namespace logic {
                 Board->currentLocations[Board->findNextOpenStart(Board->currentLocations[endLocation])] = Board->currentLocations[endLocation];
                 Board->currentLocations[endLocation] = color;
                 //Slide if on slide square
-                endLocation = Board->checkSlide(Player, endLocation);
+                endLocation = Board->checkSlide(Player, endLocation, pieceDetection);
                 Board->currentLocations[movingFrom] = 0;
             }
             else {
                 int opponentColor = Board->currentLocations[endLocation];
                 Board->currentLocations[movingFrom] = opponentColor;
                 //Slide if on slide square
-                int opponentPosition = Board->checkSlide(Player, movingFrom);
+                int opponentPosition = Board->checkSlide(Player, movingFrom, pieceDetection);
                 Board->currentLocations[endLocation] = color;
                 //Slide if on slide square
-                endLocation = Board->checkSlide(Player, endLocation);
+                endLocation = Board->checkSlide(Player, endLocation, pieceDetection);
                 Serial.print("Opponent's pawn swapped with your pawn.");
             }
         }

--- a/src/game_logic/logic_special.cpp
+++ b/src/game_logic/logic_special.cpp
@@ -124,7 +124,7 @@ namespace logic {
         }
         TaskHandle_t led_task = NULL;
         led_control::indicate_moves({location}, color, start, &led_task);
-        while (!Serial.available()) {}
+        while (!pieceDetection->hasChangedSensor()) {} // wait until player chooses a piece
         vTaskDelete(led_task); // turn off leds
         FastLED.clear();
         FastLED.show();

--- a/src/game_logic/logic_special.cpp
+++ b/src/game_logic/logic_special.cpp
@@ -32,9 +32,7 @@ namespace logic {
             Board->currentLocations[Calc->movingFrom] = 0;
             //Slide if on slide square
             int newLocation = Board->checkSlide(Player, opponentPawn);
-            Serial.println("Press any key to confirm opponent's pawn has been sent back to start and your pawn has been set in their previous location.");
-            while (!Serial.available()) {}
-            Serial.read();
+            Serial.println("Opponent's pawn has been sent back to start and your pawn has been set in their previous location.");
         }
     }
 
@@ -126,9 +124,7 @@ namespace logic {
         
         //If piece hits other piece, send other piece back to start
         if (Board->currentLocations[location] != 0) {
-            Serial.print("COLLISION: Send opponent's piece back to start. Press any key to confirm: ");
-            while (!Serial.available()) {}
-            Serial.read();
+            Serial.print("COLLISION: Send opponent's piece back to start.");
             Board->currentLocations[Board->findNextOpenStart(Board->currentLocations[location])] = Board->currentLocations[location];
         }
         Board->currentLocations[location] = color;
@@ -158,9 +154,7 @@ namespace logic {
                 Board->currentLocations[movingFrom] = 0;
             } 
             else if (endLocation == (movingFrom + 11)%44) {
-                Serial.print("COLLISION: Send opponent's piece back to start. Press any key to confirm: ");
-                while (!Serial.available()) {}
-                Serial.read();
+                Serial.print("COLLISION: Send opponent's piece back to start.");
                 Board->currentLocations[Board->findNextOpenStart(Board->currentLocations[endLocation])] = Board->currentLocations[endLocation];
                 Board->currentLocations[endLocation] = color;
                 //Slide if on slide square
@@ -175,9 +169,7 @@ namespace logic {
                 Board->currentLocations[endLocation] = color;
                 //Slide if on slide square
                 endLocation = Board->checkSlide(Player, endLocation);
-                Serial.print("Press any key to confirm opponent's pawn swapped with your pawn.");
-                while (!Serial.available()) {}
-                Serial.read();
+                Serial.print("Opponent's pawn swapped with your pawn.");
             }
         }
     }

--- a/src/game_logic/logic_terminal.cpp
+++ b/src/game_logic/logic_terminal.cpp
@@ -131,7 +131,10 @@ namespace logic {
         }
 
         // Turn off led after the correct piece is chosen
-        vTaskDelete(led_task);
+        if (led_task != NULL) {
+            vTaskDelete(led_task); // turn off leds
+            led_task = NULL;
+        }
         Calc->movingFrom = location;
         //setPlayerColor();
     }

--- a/src/game_logic/logic_terminal.cpp
+++ b/src/game_logic/logic_terminal.cpp
@@ -113,8 +113,7 @@ namespace logic {
         }
 
         // indicate which pieces can move
-        TaskHandle_t led_task = NULL;
-        led_control::indicate_moves(validPieces, Player->getPlayerColor(Player->currentPlayer), 255, &led_task);
+        led_control::indicate_moves(validPieces, Player->getPlayerColor(Player->currentPlayer), 255);
 
         int location;
         Serial.print("Select a location to move " + String(Player->currentPlayer + 1) + "'s piece from: ");
@@ -131,10 +130,7 @@ namespace logic {
         }
 
         // Turn off led after the correct piece is chosen
-        if (led_task != NULL) {
-            vTaskDelete(led_task); // turn off leds
-            led_task = NULL;
-        }
+        led_control::stopIndicateMoves();
         Calc->movingFrom = location;
         //setPlayerColor();
     }

--- a/src/led_control/led.cpp
+++ b/src/led_control/led.cpp
@@ -163,6 +163,26 @@ void indicate_moves(const vector<int>& possibleMoves, int color, int start_tile,
     xTaskCreate(led_control::ledTask, "LED Task", 2048, NULL, 1, taskHandle);
 }
 
+void showPlayerPositions(int player_number, TaskHandle_t* taskHandle, logic::LogicBoard* board) {
+  possible_moves_led = {};
+  for (int i = 0; i < logic::kBoardSize; i++) {
+    if (board->currentLocations[i] == player_number) {
+      possible_moves_led.push_back(i);
+    }
+  }
+  led_color = led_control::number_to_color(player_number);
+  start_pos = 255;
+
+  xTaskCreate(
+    led_control::ledTask,
+    "Flash Current Player Positions",
+    2048,
+    NULL,
+    1,
+    taskHandle
+  );
+}
+
 void showStartPositions(int num_players, TaskHandle_t* taskHandle) {
   xTaskCreate(
     led_control::prvShowStartPositions,

--- a/src/led_control/led.cpp
+++ b/src/led_control/led.cpp
@@ -52,11 +52,11 @@ void indicate_move(std::vector<int> indexes, CRGB color)
     FastLED.leds()[indexes[i]] = color;
     FastLED.leds()[indexes[i]].fadeLightBy(200);
     FastLED.show();
-    FastLED.delay(75);
+    vTaskDelay(pdMS_TO_TICKS(100));
   }
   FastLED.leds()[indexes[indexes.size()-2]].fadeLightBy(230);
   FastLED.leds()[indexes[indexes.size()-1]].fadeLightBy(200);
-  FastLED.delay(75);
+  vTaskDelay(pdMS_TO_TICKS(100));
   FastLED.show();
   FastLED.clear();
   FastLED.show();
@@ -189,8 +189,51 @@ void prvShowStartPositions(void *pvParameters) {
   }
 }
 
+void slidePiece(SlideStruct slide, TaskHandle_t* taskHandle) {
+  xTaskCreate(
+    led_control::prvShowStartPositions,
+    "Show Start Positions",
+    2048,
+    &slide,
+    1,
+    taskHandle
+  );
+}
+
+void prvShowSlide(void *pvParameters) {
+  SlideStruct* slide = static_cast<SlideStruct*>(pvParameters);
+  std::vector<int> indexes;
+  for (int i = slide->start_location; i <= slide->end_location; ++i) {
+    indexes.push_back(i);
+  }
+  CRGB color = number_to_color(slide->color);
+  
+  while(1) {
+    FastLED.leds()[indexes[0]] = color;
+    for (int i = 0; i < indexes.size(); ++i) {
+      if (i >= 2) {
+        FastLED.leds()[indexes[i-2]].fadeLightBy(230);
+        FastLED.leds()[indexes[i-1]].fadeLightBy(200);
+      }
+      FastLED.leds()[indexes[i]] = color;
+      FastLED.leds()[indexes[i]].fadeLightBy(200);
+      FastLED.show();
+      vTaskDelay(pdMS_TO_TICKS(100));
+    }
+    FastLED.leds()[indexes[indexes.size()-2]].fadeLightBy(230);
+    FastLED.leds()[indexes[indexes.size()-1]].fadeLightBy(200);
+    vTaskDelay(pdMS_TO_TICKS(100));
+    FastLED.show();
+    FastLED.clear();
+
+    FastLED.show();
+  }
+}
+
 void showWinner(int player_number)
 {
+  FastLED.clear();
+  FastLED.show();
   CRGB color = number_to_color(player_number);
   for (int itr=0; itr < 10; itr++) {
     for (int tile=0; tile < kBoardSideLength*2; tile++){

--- a/src/led_control/led.cpp
+++ b/src/led_control/led.cpp
@@ -160,7 +160,33 @@ void indicate_moves(const vector<int>& possibleMoves, int color, int start_tile,
     FastLED.clear();
     FastLED.show();
     
-    xTaskCreate(led_control::ledTask, "LED Task", 4096, NULL, 1, taskHandle);
+    xTaskCreate(led_control::ledTask, "LED Task", 2048, NULL, 1, taskHandle);
+}
+
+void showStartPositions(int num_players, TaskHandle_t* taskHandle) {
+  xTaskCreate(
+    led_control::prvShowStartPositions,
+    "Show Start Positions",
+    2048,
+    &num_players,
+    1,
+    taskHandle
+  );
+}
+
+void prvShowStartPositions(void *pvParameters) {
+  int* num_players = static_cast<int*>(pvParameters);
+  while(1) {
+    for (int on_off = 0; on_off < 2; on_off++) {
+      for (int i = 0; i < *num_players; i++) {
+        for (int j = 0; j < 3; j++) {
+          FastLED.leds()[logic::kStartLocations[i*3+j]] = on_off ? number_to_color(i+1) : CRGB::Black;
+        }
+      }
+      FastLED.show();
+      vTaskDelay(pdMS_TO_TICKS(500));
+    }
+  }
 }
 
 void showWinner(int player_number)

--- a/src/led_control/led.cpp
+++ b/src/led_control/led.cpp
@@ -117,6 +117,8 @@ CRGB number_to_color(int color)
       return CRGB::Green;
     case 4:
       return CRGB::Blue;
+    default:
+      return CRGB::Black;
   }
 }
 
@@ -170,6 +172,7 @@ void showPlayerPositions(int player_number, TaskHandle_t* taskHandle, const logi
   for (int i = 0; i < logic::kBoardSize; i++) {
     if (board.currentLocations[i] == player_number) {
       possible_moves_led.push_back(i);
+      Serial.println("Player " + String(player_number) + " is at tile " + String(i));
     }
   }
   led_color = led_control::number_to_color(player_number);

--- a/src/led_control/led.cpp
+++ b/src/led_control/led.cpp
@@ -270,13 +270,15 @@ void prvShowStartPositions(void *pvParameters) {
 }
 
 void slidePiece(SlideStruct slide) {
-  g_slide = slide;
+  g_slide.color = slide.color;
+  g_slide.start_location = slide.start_location;
+  g_slide.end_location = slide.end_location;
 
   if (slide_task_handle == NULL) {
     xTaskCreate(
       led_control::prvShowSlide,
       "Show Start Positions",
-      2048,
+      4096,
       NULL,
       1,
       &slide_task_handle
@@ -289,9 +291,11 @@ void slidePiece(SlideStruct slide) {
 
 void stopSlide() {
   if (eTaskGetState(slide_task_handle) != eDeleted) {
-    vTaskSuspend(slide_task_handle);
+    vTaskDelete(slide_task_handle);
     slide_task_handle = NULL;
   }
+  FastLED.clear();
+  FastLED.show();
 }
 
 void prvShowSlide(void *pvParameters) {
@@ -302,19 +306,19 @@ void prvShowSlide(void *pvParameters) {
   CRGB color = number_to_color(g_slide.color);
   
   while(1) {
-    FastLED.leds()[indexes[0]] = color;
+    FastLED.leds()[indexes.at(0)] = color;
     for (int i = 0; i < indexes.size(); ++i) {
       if (i >= 2) {
-        FastLED.leds()[indexes[i-2]].fadeLightBy(230);
-        FastLED.leds()[indexes[i-1]].fadeLightBy(200);
+        FastLED.leds()[indexes.at(i-2)].fadeLightBy(230);
+        FastLED.leds()[indexes.at(i-1)].fadeLightBy(200);
       }
-      FastLED.leds()[indexes[i]] = color;
-      FastLED.leds()[indexes[i]].fadeLightBy(200);
+      FastLED.leds()[indexes.at(i)] = color;
+      FastLED.leds()[indexes.at(i)].fadeLightBy(200);
       FastLED.show();
       vTaskDelay(pdMS_TO_TICKS(100));
     }
-    FastLED.leds()[indexes[indexes.size()-2]].fadeLightBy(230);
-    FastLED.leds()[indexes[indexes.size()-1]].fadeLightBy(200);
+    FastLED.leds()[indexes.at(indexes.size()-2)].fadeLightBy(230);
+    FastLED.leds()[indexes.at(indexes.size()-1)].fadeLightBy(200);
     vTaskDelay(pdMS_TO_TICKS(100));
     FastLED.show();
     FastLED.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,16 +29,16 @@ void setup() {
   FastLED.show();
   set_max_power_in_volts_and_milliamps(5, 100);
   Serial.begin(9600);
-  mySerial.begin(9600, SERIAL_8N1, 12, 14);
+  // mySerial.begin(9600, SERIAL_8N1, 12, 14);
   
-  xTaskCreate(
-    AudioPotTask,         // Task function
-    "Potentiometer read",      // Name of the task
-    2048,             // Stack size (in bytes)
-    NULL,             // Task parameter
-    2,                // Priority
-    NULL              // Task handle
-  );
+  // xTaskCreate(
+  //   AudioPotTask,         // Task function
+  //   "Potentiometer read",      // Name of the task
+  //   2048,             // Stack size (in bytes)
+  //   NULL,             // Task parameter
+  //   2,                // Priority
+  //   NULL              // Task handle
+  // );
 
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,28 +1,22 @@
 #include <Arduino.h>
 #include "game_logic/logic_controller.hpp" // for LogicController
+#include "led_control/led.hpp" // for led control
 
 #define NUM_LEDS 80
 #define DATA_PIN 13
-
 
 CRGB leds[NUM_LEDS];
 void setup() {
   FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
   FastLED.clear();
   FastLED.show();
-  set_max_power_in_volts_and_milliamps(5, 200);
+  set_max_power_in_volts_and_milliamps(5, 100);
   Serial.begin(9600);
   logic::LogicController* logicController = new logic::LogicController;
   logicController->startGame(); 
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-  // static uint8_t hue = 0; // Tracks the color hue
-  // for (int i = 0; i < NUM_LEDS; i++) {
-  //   leds[i] = CHSV(hue, 255, 255); // Set each LED to the current hue
-  // }
-  // FastLED.show();
-  // hue++; // Increment the hue for the next cycle
-  // delay(20); // Small delay for smooth cycling
+  // logic::LogicController* logicController = new logic::LogicController;
+  // logicController->startGame(); 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,4 @@ void loop() {
   FastLED.show();
   logic::LogicController* logicController = new logic::LogicController;
   logicController->startGame(); 
-
-
-
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,7 +49,5 @@ void loop() {
   logicController->startGame(); 
 
 
-  // delay(10000);
-  // audio::playTrack(1); // Play track 1
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,22 +1,55 @@
 #include <Arduino.h>
 #include "game_logic/logic_controller.hpp" // for LogicController
 #include "led_control/led.hpp" // for led control
+#include "audio/audio.hpp" // for audio control
 
 #define NUM_LEDS 80
 #define DATA_PIN 13
+#define POT_PIN 27  // Pin for the potentiometer
+HardwareSerial mySerial(1);
 
 CRGB leds[NUM_LEDS];
+
+void AudioPotTask(void *parameter) {
+  uint16_t pot_read = 0; // Stores the most recent reading from the potentiometer
+  uint32_t scaled_pot = 0; // Scaled value of the potentiometer
+  while (true) {
+    pot_read = analogRead(POT_PIN);
+    scaled_pot = pot_read * 30 / 4095; // Scale 0-4095 to 0-30
+    // audio::setVolume(scaled_pot); // Set brightness
+    Serial.print(("Setting volume to: "));
+    Serial.println(scaled_pot);
+    vTaskDelay(1000 / portTICK_PERIOD_MS); // Avoid overwhelming the CPU
+  }
+}
+
 void setup() {
   FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
   FastLED.clear();
   FastLED.show();
   set_max_power_in_volts_and_milliamps(5, 100);
   Serial.begin(9600);
-  logic::LogicController* logicController = new logic::LogicController;
-  logicController->startGame(); 
+  mySerial.begin(9600, SERIAL_8N1, 12, 14);
+  
+  xTaskCreate(
+    AudioPotTask,         // Task function
+    "Potentiometer read",      // Name of the task
+    2048,             // Stack size (in bytes)
+    NULL,             // Task parameter
+    2,                // Priority
+    NULL              // Task handle
+  );
+
 }
 
 void loop() {
-  // logic::LogicController* logicController = new logic::LogicController;
-  // logicController->startGame(); 
+  FastLED.clear();
+  FastLED.show();
+  logic::LogicController* logicController = new logic::LogicController;
+  logicController->startGame(); 
+
+
+  // delay(10000);
+  // audio::playTrack(1); // Play track 1
+
 }


### PR DESCRIPTION
FreeRTOS tasks were being created and destroyed every time they were needed. This was possibly causing heap fragmentations as it was constantly allocating and freeing memory that could have been reused. To fix, most of the tasks are now suspended and resumed as needed.